### PR TITLE
fix: codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,4 @@
-# Changes to boilerplates must be signed off by infra
-*   @TheCodingDen/infra-admins
+# Project maintainer
+*   @BobobUnicorn
+# Working group
+*   @TheCodingDen/projects-bot


### PR DESCRIPTION
This fixes the CODEOWNERS file, which was accidentally overwritten with a boilerplate merge.