### PR TITLE
fix: don't try and reject migrated submissions

### DIFF
--- a/src/db/submission.ts
+++ b/src/db/submission.ts
@@ -88,9 +88,14 @@ export async function fetchSubmissionsByMemberId (
   const out: PendingSubmission[] = []
 
   for (const submission of data) {
+    if (submission.state === 'ACCEPTED' || submission.state === 'DENIED') {
+      logger.debug(`Skipping automated rejection of ${submission.state.toLowerCase()} submission ${submission.id}`)
+      continue
+    }
+
     const pending: PendingSubmission = {
       ...submission,
-      // It's going to be an error state anyways
+      // It's going to be an error state anyways, because the user will not resolve.
       state: 'ERROR',
       tech: submission.techUsed,
       links: {


### PR DESCRIPTION
This fixes an oversight with the flow that removes submissions when a submitter leaves, caused by the migration we performed. We may want to add options to `runCatching` to fully suppress errors, for example here where we fetch Discord objects that may not exist for whatever reason.