### PR TITLE
feat: better source URLs

### DIFF
--- a/src/commands/cleanup.ts
+++ b/src/commands/cleanup.ts
@@ -77,6 +77,8 @@ export default class CleanupCommand extends SlashCommand {
       if (isValidated(submission)) {
         await submission.reviewThread.setArchived(true)
         await submission.submissionMessage.delete()
+
+        return 'deleted'
       }
 
       return 'not-delete'

--- a/src/utils/embed.ts
+++ b/src/utils/embed.ts
@@ -141,6 +141,9 @@ function createProcessingEmbed (submission: ValidatedSubmission): APIEmbed {
     .map((v) => `${v.voter.user.tag}`)
     .join('\n') || 'None'
 
+  const [,user, repo] = new URL(submission.links.source).pathname.split('/')
+  const vscDevURL = `https://vscode.dev/github/${user}/${repo}`
+
   return createEmbedBase(submission)
     .setFields(
       {
@@ -149,7 +152,7 @@ function createProcessingEmbed (submission: ValidatedSubmission): APIEmbed {
       },
       {
         name: 'Source',
-        value: submission.links.source
+        value: `${createClickableURLString(submission.links.source)} | [Open in vscode.dev](${vscDevURL})`
       },
       {
         name: 'Technologies',


### PR DESCRIPTION
this adds vscode.dev links to the embeds, which allows in-browser viewing of submissions. it also changes standard source links to use the same format we use on the public embeds.