### PR TITLE
fix: allow rejection of errored submission in the case of invalid-id

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -84,7 +84,7 @@ async function sendMessageToPrivateSubmission (submission: ApiSubmission): Promi
   const submissionMessage = await runCatching(
     async () => {
       const { privateSubmissions } = config.channels()
-      await privateSubmissions.send({
+      return await privateSubmissions.send({
         embeds: [embed],
         components: [
           new ActionRowBuilder<ButtonBuilder>().addComponents(

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -141,7 +141,7 @@ async function handleResolutionFailure (
   reviewThread: ThreadChannel,
   failureReason: string
 ): Promise<ApiError> {
-  logger.error(
+  logger.warn(
         `Failed to fetch required values for submission ${stringify.submission(
           submission
         )} with reason ${failureReason}`

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -54,10 +54,16 @@ function validateRequest (req: FastifyRequest): ApiAction<ApiSubmission> {
   assert(typeof body === 'object' && !!body, 'body was not an object')
 
   logger.trace('Body was valid')
+
+  // Fastify validated the shape for us
+  const castBody = body as ApiSubmission
+
+  // Default to "None" if no string is provided from the form
+  castBody.links.other = castBody.links.other || 'None'
+
   return {
     error: false,
-    // Fastify validated the shape for us
-    data: body as ApiSubmission
+    data: castBody
   }
 }
 

--- a/src/commands/reject.ts
+++ b/src/commands/reject.ts
@@ -48,7 +48,9 @@ export default class RejectCommand extends SlashCommand {
       return
     }
 
-    if (submission.state === 'ERROR') {
+    // Only allow rejection of errored projects if the reason
+    // is invalid ID, not some other failure.
+    if (submission.state === 'ERROR' && rawReason !== 'invalid-id') {
       commandLog.warning({
         type: 'text',
         content:

--- a/src/commands/reject.ts
+++ b/src/commands/reject.ts
@@ -104,6 +104,17 @@ export default class RejectCommand extends SlashCommand {
     })
 
     if (rejectionResult.error) {
+      if (rejectionResult.message === 'didnt-run-cleanup') {
+        return commandLog.info({
+          type: 'text',
+          content: 'Could not cleanup, submission was errored. Please cleanup manually.',
+          ctx,
+          extraOpts: {
+            ephemeral: false
+          }
+        })
+      }
+
       // Could not reject, send template to review thread
       commandLog.info({
         type: 'text',

--- a/src/commands/reject.ts
+++ b/src/commands/reject.ts
@@ -76,7 +76,7 @@ export default class RejectCommand extends SlashCommand {
     logger.debug(
       `Starting instant rejection for submission ${stringify.submission(
         submission
-      )} (reason: ${logOutput})`
+      )} (reason: ${logOutput} / ${rawReason})`
     )
 
     // This means Discord gave us a reason that wasnt in the object,

--- a/src/vote/action.ts
+++ b/src/vote/action.ts
@@ -359,7 +359,7 @@ export async function forceReject (
     // This is an extreme edge case for the API design to handle.
     return {
       error: true,
-      message: 'Did not run cleanup, submission was in an errored state. Please clean up manually.'
+      message: 'didnt-run-cleanup'
     }
   }
 

--- a/src/vote/action.ts
+++ b/src/vote/action.ts
@@ -293,11 +293,9 @@ export async function forceReject (
   submission: ValidatedSubmission | PendingSubmission,
   details: RejectionDetails
 ): Promise<VoteModificationResult> {
-  // Do not allow errored or paused submissions to be rejected, this should be checked by the caller
-  assert(
-    submission.state !== 'ERROR',
-    'attempted to force-reject an ERROR state submission'
-  )
+  // Do not allow paused submissions to be rejected, this should be checked by the caller
+  // Errored submissions are acceptable because invalid-id cases will be in the error state
+  // This case should be validated by callers
   assert(
     submission.state !== 'PAUSED',
     'attempted to force-reject an PAUSED state submission'


### PR DESCRIPTION
This makes the instant rejection flow support rejection of errored submissions, but only in the case of the user ID being invalid.

It squashes bugs found within this flow too.