### PR TITLE
fix: log to logger before Discord

### DIFF
--- a/src/utils/exception.ts
+++ b/src/utils/exception.ts
@@ -6,11 +6,11 @@ import { internalLog } from '../communication/internal'
  */
 export function setup (): void {
   process.setUncaughtExceptionCaptureCallback(err => {
+    logger.error(err)
     internalLog.error({
       type: 'text',
       content: `Encountered uncaught exception: ${err.message} \n ${err.stack}`,
       ctx: undefined
     })
-    logger.error(err)
   })
 }


### PR DESCRIPTION
This adjusts our uncaught exception handler to be more useful. Previously, it would try logging to Discord before the pino logger.
This is problematic because if we encounter problems before d.js is up (e.g with Prisma) they will fail to log, as the internalLog is not ready.